### PR TITLE
Fix/dialog import v2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "@radix-ui/react-tabs": "^1.1.12",
         "@supabase/auth-helpers-nextjs": "^0.10.0",
         "@supabase/auth-helpers-react": "^0.5.0",
+        "@supabase/ssr": "^0.6.1",
         "@supabase/supabase-js": "^2.52.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -2009,6 +2010,18 @@
         "ws": "^8.18.2"
       }
     },
+    "node_modules/@supabase/ssr": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@supabase/ssr/-/ssr-0.6.1.tgz",
+      "integrity": "sha512-QtQgEMvaDzr77Mk3vZ3jWg2/y+D8tExYF7vcJT+wQ8ysuvOeGGjYbZlvj5bHYsj/SpC0bihcisnwPrM4Gp5G4g==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1"
+      },
+      "peerDependencies": {
+        "@supabase/supabase-js": "^2.43.4"
+      }
+    },
     "node_modules/@supabase/storage-js": {
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.7.1.tgz",
@@ -3591,6 +3604,15 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
+      "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@radix-ui/react-tabs": "^1.1.12",
     "@supabase/auth-helpers-nextjs": "^0.10.0",
     "@supabase/auth-helpers-react": "^0.5.0",
+    "@supabase/ssr": "^0.6.1",
     "@supabase/supabase-js": "^2.52.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/src/app/api/gpt-comment/route.ts
+++ b/src/app/api/gpt-comment/route.ts
@@ -5,34 +5,57 @@ import { cookies } from 'next/headers';
 
 const USAGE_LIMIT = Number.parseInt(process.env.MAX_USAGE_PER_DAY ?? '', 10) || 100;
 
+/** Cookieの中身で使う可能性がある形 */
+type TokenShapes =
+  | { access_token?: unknown; currentSession?: { access_token?: unknown }; session?: { access_token?: unknown } }
+  | string[]
+  | string
+  | null;
+
 /** Authorizationヘッダ or Cookie から access_token を取り出す（配列/二重JSONにも対応） */
 async function getAccessToken(req: NextRequest): Promise<string | null> {
   // 1) Authorization: Bearer xxx を優先
   const h = req.headers.get('authorization');
   if (h && /^bearer\s+/i.test(h)) return h.replace(/^bearer\s+/i, '').trim();
 
-  // 2) Supabase の auth cookie を解析（いくつかのフォーマットに対応）
+  // 2) Supabase の auth cookie を解析
   const jar = await cookies();
-  const c = jar.getAll().find(v => /-auth-token$/.test(v.name));
+  const c = jar.getAll().find((v) => /-auth-token$/.test(v.name));
   if (!c?.value) return null;
 
   // URLデコード
-  let raw: any = (() => {
-    try { return decodeURIComponent(c.value); } catch { return c.value; }
+  let raw: unknown = (() => {
+    try {
+      return decodeURIComponent(c.value);
+    } catch {
+      return c.value;
+    }
   })();
 
-  // 最大2回まで JSON を再帰的に解凍（"文字列化されたJSON"ケース対策）
-  const tryParse = (x: any) => { try { return JSON.parse(x); } catch { return x; } };
+  // 最大2回まで JSON.parse を試す
+  const tryParse = (x: unknown): unknown => {
+    if (typeof x === 'string') {
+      try {
+        return JSON.parse(x);
+      } catch {
+        return x;
+      }
+    }
+    return x;
+  };
   raw = tryParse(raw);
-  raw = typeof raw === 'string' ? tryParse(raw) : raw;
+  if (typeof raw === 'string') raw = tryParse(raw);
 
   // 旧フォーマット: ["access_token","refresh_token"]
   if (Array.isArray(raw) && typeof raw[0] === 'string') return raw[0];
 
   // 新フォーマット群
-  if (typeof raw?.access_token === 'string') return raw.access_token;
-  if (typeof raw?.currentSession?.access_token === 'string') return raw.currentSession.access_token;
-  if (typeof raw?.session?.access_token === 'string') return raw.session.access_token;
+  if (raw && typeof raw === 'object') {
+    const r = raw as Extract<TokenShapes, { [k: string]: unknown }>;
+    if (typeof r.access_token === 'string') return r.access_token;
+    if (r.currentSession && typeof r.currentSession.access_token === 'string') return r.currentSession.access_token;
+    if (r.session && typeof r.session.access_token === 'string') return r.session.access_token;
+  }
 
   return null;
 }
@@ -61,8 +84,8 @@ function localCommentFrom(memo: string) {
 
 export async function POST(req: NextRequest) {
   try {
-    const body = await req.json().catch(() => ({}));
-    const memo: string = (body?.memo ?? '').toString();
+    const body = (await req.json().catch(() => ({}))) as { memo?: unknown };
+    const memo = typeof body.memo === 'string' ? body.memo : '';
     if (!memo.trim()) return NextResponse.json({ error: 'Memo is missing.' }, { status: 400 });
 
     const token = await getAccessToken(req);
@@ -75,14 +98,17 @@ export async function POST(req: NextRequest) {
       p_delta: 1,
       p_max: USAGE_LIMIT,
     });
+
+    // エラー型に any を使わず、最小限の形に絞って型主張
+    const status = (incError as { status?: number } | null | undefined)?.status;
+    if (status === 401) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     if (incError) {
-      const s = (incError as any)?.status ?? 0;
-      if (s === 401) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
       console.error('increment_usage failed:', incError);
       return NextResponse.json({ error: 'Failed to increment usage.' }, { status: 500 });
     }
 
-    const incRow = Array.isArray(incData) ? incData[0] : incData;
+    const incRow =
+      (Array.isArray(incData) ? incData[0] : incData) as { ok?: boolean; new_total?: number } | null;
     if (!incRow?.ok) {
       return NextResponse.json(
         { error: 'Usage limit reached.', usage_total: incRow?.new_total ?? null, usage_limit: USAGE_LIMIT },
@@ -94,7 +120,7 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({
       ok: true,
       comment,
-      usage_total: incRow.new_total,
+      usage_total: incRow.new_total ?? null,
       usage_limit: USAGE_LIMIT,
     });
   } catch (e) {

--- a/src/app/lib/supabase/client.ts
+++ b/src/app/lib/supabase/client.ts
@@ -1,9 +1,9 @@
-'use client'
+// lib/supabase/client.ts
+'use client';
 
-import { createPagesBrowserClient } from '@supabase/auth-helpers-nextjs'
-import { Database } from '@/lib/database.types'
+import { createBrowserClient } from '@supabase/ssr';
 
-export const supabase = createPagesBrowserClient<Database>({
-  supabaseUrl: process.env.NEXT_PUBLIC_SUPABASE_URL!,
-  supabaseKey: process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
-})
+export const supabase = createBrowserClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL!,
+  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+);

--- a/src/app/records/new/page.tsx
+++ b/src/app/records/new/page.tsx
@@ -117,6 +117,7 @@ export default function RecordNewPage() {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ memo: prompt }),
+        credentials: 'include',
       });
 
       const result = await res.json();


### PR DESCRIPTION
# Harden usage limiting & auth for `/api/gpt-comment` (stateless Supabase client + RPC); fix 401/429; remove `any`

## Summary

Refactors the GPT comment API and database layer to be secure, reliable, and Vercel-friendly.

* Usage limiting moved into a Postgres RPC (no direct access to non-`public` schemas).
* Route uses a **stateless** Supabase client (no cookie mutations).
* Auth accepted via **Authorization header** *or* **Supabase auth cookie**, fixing `401`.
* Atomic increment with deterministic return shape, fixing false `429`.
* Type cleanup to satisfy `@typescript-eslint/no-explicit-any`.

## Why

* Supabase REST exposes only `public` / `graphql_public`; touching `app` directly caused errors.
* Server routes were mutating cookies, sometimes deleting `sb-…-auth-token`.
* App-side pre-check vs DB limit drift produced incorrect `429`.
* Vercel build failed on `no-explicit-any`.

## What Changed

### API

* `src/app/api/gpt-comment/route.ts`

  * Switch to **stateless** `@supabase/supabase-js` client (`persistSession:false`).
  * Extract token from `Authorization: Bearer <token>` **or** Supabase auth cookie (supports array & nested JSON formats).
  * Call RPC first (`increment_usage(p_delta, p_max)`) and rely on DB for truth.
  * Response: `{ ok, comment, usage_total, usage_limit }`.
  * Replace all `any` with `unknown` + safe narrowing.

### DB (SQL)

* Table: `app.api_usage` (RLS enabled; no policies → direct access denied).
* RPC: `public.increment_usage(p_delta int, p_max int)`

  * `SECURITY DEFINER`, `SET search_path = public, app`.
  * Locks `id='global'`, inserts if missing.
  * Atomic update; **always returns one row**:

    * success → `(ok=true, new_total)`
    * limit reached → `(ok=false, new_total)`
* (Optional) Helper: `public.get_usage_total()`.
* Grants: `EXECUTE` to `authenticated` only.

## Config / Env

Add to `.env.local`:

```env
MAX_USAGE_PER_DAY=100
NEXT_PUBLIC_SUPABASE_URL=...
NEXT_PUBLIC_SUPABASE_ANON_KEY=...
```

Supabase Auth:

* **Site URL**: your domain (or `http://localhost:3000`)
* **Cookie domain**: empty or your domain

## Migration Steps

1. Run SQL (schema/table + RPC + grants).
2. Deploy code.
3. (Optional) Reset for testing:

   ```sql
   update app.api_usage set usage_count = 0 where id = 'global';
   ```

## How to Test

1. Sign in and confirm `sb-…-auth-token` cookie exists.
2. Trigger **Regenerate AI comment**:

   * Expect `200` with `{ ok:true, usage_total, usage_limit }`.
   * DB `app.api_usage.usage_count` increments by 1.
3. Hit the limit (set a small `MAX_USAGE_PER_DAY` or loop calls):

   * Expect `429` with `{ error:'Usage limit reached.', usage_total }`.
4. Verify cookie is **not** removed after requests.
5. Vercel build passes (no `no-explicit-any` violations).

## Security Notes

* Data table remains in `app` with RLS enabled; only RPC is exposed.
* `increment_usage` runs with controlled privileges via `SECURITY DEFINER`.
* `anon` **does not** have EXECUTE on the RPC.

## Risks & Rollback

* Low risk; behavior is additive and guarded by RPC.
* Rollback: revert route and drop new RPC:

  ```sql
  drop function if exists public.increment_usage(int,int);
  ```

---

### Appendix: Key SQL

```sql
create schema if not exists app;

create table if not exists app.api_usage (
  id          text primary key,          -- use 'global'
  usage_count integer not null default 0,
  updated_at  timestamptz not null default now(),
  deleted_at  timestamptz
);

alter table app.api_usage enable row level security;

create or replace function public.increment_usage(
  p_delta integer default 1,
  p_max   integer default 100
)
returns table(ok boolean, new_total integer)
language plpgsql
security definer
set search_path = public, app
as $$
declare
  v_total integer;
begin
  perform 1 from app.api_usage where id = 'global' for update;
  if not found then
    insert into app.api_usage(id, usage_count) values ('global', 0);
  end if;

  update app.api_usage
     set usage_count = usage_count + p_delta,
         updated_at  = now()
   where id = 'global'
     and usage_count + p_delta <= p_max
  returning usage_count into v_total;

  if found then
    return query select true, v_total;
  else
    select usage_count into v_total from app.api_usage where id = 'global';
    return query select false, v_total;
  end if;
end;
$$;

grant execute on function public.increment_usage(int, int) to authenticated;
revoke execute on function public.increment_usage(int, int) from anon;

create or replace function public.get_usage_total()
returns integer
language sql
security definer
set search_path = public, app
as $$
  select coalesce((select usage_count from app.api_usage where id = 'global'), 0);
$$;

grant execute on function public.get_usage_total() to authenticated;
```
